### PR TITLE
feat: 二文字コールも出題されるようにした

### DIFF
--- a/src/modes/call_lesson.rs
+++ b/src/modes/call_lesson.rs
@@ -211,7 +211,14 @@ fn generate_callsign() -> String {
                 + rand_char(ALNUM)
                 + rand_char(ALNUM)
                 + rand_char(ALNUM),
-        15..=255 => "J".to_string()
+        15..=18 => "JA".to_owned()
+                + rand_char(NUM)
+                + rand_char(ALPHA)
+                + rand_char(ALPHA),
+        19 => "JR6".to_owned()
+                + rand_char(ALPHA)
+                + rand_char(ALPHA),
+        20..=255 => "J".to_string()
                 + rand_char(JA_PRF)
                 + rand_char(NUM)
                 + rand_char(ALPHA)


### PR DESCRIPTION
2文字コールはプレフィックスがJA[0~9]かJR6(沖縄)のパターンのみらしい(レピーター局、記念局を除く)
現存しないコールサインは除くとかは面倒くさいのでやめておきます。