### PR TITLE
prefixがJD2~JD9, JD0のコールサインが出題されないようにした

### DIFF
--- a/src/modes/lesson/callsign.rs
+++ b/src/modes/lesson/callsign.rs
@@ -3,7 +3,7 @@ use crate::modes::lesson::rand_char;
 const ALPHA: &'static str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const ALNUM: &'static str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 const NUM: &'static str = "0123456789";
-const JA_PRF: &'static str = "ADEFGHJKLMNPQRS";
+const JA_PRF: &'static str = "AEFGHIJKLMNOPQRS";
 
 pub struct JaCallsignGen;
 impl Iterator for JaCallsignGen {
@@ -30,7 +30,8 @@ impl Iterator for JaCallsignGen {
             }
             15..=18 => "JA".to_owned() + rand_char(NUM) + rand_char(ALPHA) + rand_char(ALPHA),
             19 => "JR6".to_owned() + rand_char(ALPHA) + rand_char(ALPHA),
-            20..=255 => {
+            20..=29 => "JD1".to_owned() + rand_char(ALPHA) + rand_char(ALPHA) + rand_char(ALPHA),
+            30..=255 => {
                 "J".to_string()
                     + rand_char(JA_PRF)
                     + rand_char(NUM)


### PR DESCRIPTION
あと何故かJA_PRFにIとOが入っていなかったので入れました。