### PR TITLE
和文練習用レッスンを追加

### DIFF
--- a/src/bot/commands/cw_lesson.rs
+++ b/src/bot/commands/cw_lesson.rs
@@ -17,10 +17,11 @@ pub fn get_lesson_gen(probset: &str) -> anyhow::Result<LessonGen> {
         "file" => Box::new(lesson::file::FileSourceGen::new(probset_args_str)?),
         "nr_allja" => Box::new(lesson::allja_number::AllJANumberGen::new()),
         "nr_acag" => Box::new(lesson::acag_number::ACAGNumberGen::new()),
+        "rand5_jp" => Box::new(lesson::japanese::JapaneseFiveCharGen {}),
         _ => {
             anyhow::bail!(
                 "unknown probset.\n".to_owned()
-                    + "available selections are: call_ja, file, nr_allja, nr_acag"
+                    + "available selections are: call_ja, file, nr_allja, nr_acag, rand5_jp"
             )
         }
     };

--- a/src/modes/lesson/japanese.rs
+++ b/src/modes/lesson/japanese.rs
@@ -1,0 +1,49 @@
+use super::LessonAnswerBox;
+use rand::Rng;
+
+// カタカナ（清音、濁音、半濁音を含む）
+const KATAKANA: &str = "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ";
+
+pub struct JapaneseFiveCharGen;
+
+impl JapaneseFiveCharGen {
+    fn random_char() -> char {
+        let mut rng = rand::thread_rng();
+        let chars: Vec<char> = KATAKANA.chars().collect();
+        chars[rng.gen_range(0..chars.len())]
+    }
+}
+
+impl Iterator for JapaneseFiveCharGen {
+    type Item = LessonAnswerBox;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut result = String::new();
+
+        // 5文字を生成
+        for _ in 0..5 {
+            result.push(Self::random_char());
+        }
+
+        Some(Box::new(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_japanese_five_char_gen() {
+        let mut gen = JapaneseFiveCharGen;
+
+        for _ in 0..10 {
+            let result = gen.next().unwrap();
+            let s = result.into_str();
+            println!("Generated: {}", s);
+
+            // 5文字であることを確認
+            assert_eq!(s.chars().count(), 5);
+        }
+    }
+}

--- a/src/modes/lesson/mod.rs
+++ b/src/modes/lesson/mod.rs
@@ -2,6 +2,7 @@ pub mod acag_number;
 pub mod allja_number;
 pub mod callsign;
 pub mod file;
+pub mod japanese;
 mod number;
 
 use anyhow::Context as _;


### PR DESCRIPTION
`probset`に`rand5_jp`を追加し、カタカナ5文字をランダムで出題するようにする。
「ガ」のような濁音、半濁音のついた文字も1文字としてカウントする。